### PR TITLE
Fix hashability of URL params and kwargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ def ttl_google():
 - Specify an optional TTL policy for cache (in seconds)
 - Extensible - add your own `HttpClient` or `Hasher` implementation for full control
 
+### Current known issues:
+- Not all `params` passed into `requests.get` are of type `dict`
+- `_UrlParams_hashabledict` should allow for other primitive hashable types
+- Certain `**kwargs` passed down into `requests.get` are unhashable and will raise exception - `headers`, `cookies`, `auth?`, `proxies` - similar solution to `_UrlParams_hashabledict` may fix it
+
 ### Setting up development environment:
 ```bash
 # From root directory where `setup.py` is located

--- a/README.md
+++ b/README.md
@@ -60,11 +60,6 @@ def ttl_google():
 - Specify an optional TTL policy for cache (in seconds)
 - Extensible - add your own `HttpClient` or `Hasher` implementation for full control
 
-### Current known issues:
-- Not all `params` passed into `requests.get` are of type `dict`
-- `_UrlParams_hashabledict` should allow for other primitive hashable types
-- Certain `**kwargs` passed down into `requests.get` are unhashable and will raise exception - `headers`, `cookies`, `auth?`, `proxies` - similar solution to `_UrlParams_hashabledict` may fix it
-
 ### Setting up development environment:
 ```bash
 # From root directory where `setup.py` is located

--- a/lru_cache_http_client/http/http_client.py
+++ b/lru_cache_http_client/http/http_client.py
@@ -1,0 +1,13 @@
+class HttpClient:
+    """
+    Template interface for valid HttpClients used by the application
+    """
+
+    def get(self, url, params=None, **kwargs):
+        pass
+
+    def make_args_hashable(self, params=None, **kwargs):
+        """
+        Given keyword args, make them all hashable
+        """
+        return params, kwargs

--- a/lru_cache_http_client/http/requests_http_client.py
+++ b/lru_cache_http_client/http/requests_http_client.py
@@ -1,13 +1,7 @@
+from lru_cache_http_client.http.http_client import HttpClient
+
 import requests
-
-
-class HttpClient:
-    """
-    Template interface for valid HttpClients used by the application
-    """
-
-    def get(self, url, params=None, **kwargs):
-        pass
+from collections.abc import Hashable
 
 
 class RequestsHttpClient(HttpClient):
@@ -26,3 +20,50 @@ class RequestsHttpClient(HttpClient):
         :rtype: requests.Response
         """
         return requests.get(url, params, **kwargs)
+
+    def make_args_hashable(self, params=None, **kwargs):
+        """
+        Make args to `get` method hashable
+        """
+
+        # params needs to be hashable
+        if params is not None:
+            if isinstance(params, dict):
+                params = _RequestsArg_hashabledict(params)
+            elif isinstance(params, list):
+                params = tuple(params)
+
+        # certain kwargs need to be converted to hashable
+        # type, notably `dict` kwargs
+        dict_kwargs = ["headers", "cookies", "proxies"]
+        for key, value in kwargs.items():
+            if key not in dict_kwargs:
+                continue
+            elif isinstance(value, dict):
+                kwargs[key] = _RequestsArg_hashabledict(value)
+
+        return params, kwargs
+
+
+class _RequestsArg_hashabledict(dict):
+    """
+    Helper wrapper around dict class to make it hashable.
+    Note that all items in dict must be of type str for this
+    to work
+    """
+
+    def __init__(self, unhashable_dict=None):
+        """
+        Given a dict, or missing val, instantiate a dict
+        that can be hashed. Useful for caching method above
+        """
+        if unhashable_dict is None:
+            unhashable_dict = {}
+        dict_items = unhashable_dict.items()
+        for key, val in dict_items:
+            if not isinstance(key, Hashable) or not isinstance(val, Hashable):
+                raise TypeError("Unhashable params passed into function")
+        super().__init__(dict_items)
+
+    def __hash__(self):
+        return hash(frozenset(sorted(self.items())))

--- a/test/http/test_lru_http_client.py
+++ b/test/http/test_lru_http_client.py
@@ -1,9 +1,34 @@
 from lru_cache_http_client.hash.hasher import Hasher
-from lru_cache_http_client.http.requests_http_client import HttpClient
+from lru_cache_http_client.http.http_client import HttpClient
 from lru_cache_http_client.http.lru_http_client import LruHttpClient
 
 import pytest
 import time
+from collections.abc import Hashable
+
+
+class TestHttpClient(HttpClient):
+    """
+    Mock HttpClient to be injected into LruHttpClient for testing
+    Unique calls to `get` will return unique vals.
+    This is useful as we're trying to test the caching abilities
+    of LruHttpClient.
+    """
+
+    count = 1
+
+    def get(self, url, params=None, **kwargs):
+        self.count += 1
+        return self.count
+
+    def make_args_hashable(self, params=None, **kwargs):
+        """
+        Hashability tests are outside of the scope of the test suite
+        """
+        for key, val in kwargs.items():
+            if not isinstance(val, Hashable):
+                kwargs[key] = None
+        return None, kwargs
 
 
 def test_invalid_http_client():
@@ -41,13 +66,6 @@ def test_same_req():
            different results
     Assert: Both responses are the same due to caching
     """
-
-    class TestHttpClient(HttpClient):
-        count = 1
-
-        def get(self, url, params=None, **kwargs):
-            self.count += 1
-            return self.count
 
     client = TestHttpClient()
     caching_client = LruHttpClient(http_client=client)
@@ -97,14 +115,6 @@ def test_req_url_params_list():
     Assert: LruHttpClient is able to make the list hashable
             and caches the request
     """
-
-    class TestHttpClient(HttpClient):
-        count = 1
-
-        def get(self, url, params=None, **kwargs):
-            self.count += 1
-            return self.count
-
     client = TestHttpClient()
     caching_client = LruHttpClient(http_client=client)
     url_params = [("a", "b"), ("c", "d")]
@@ -122,13 +132,6 @@ def test_ttl_expired():
     Assert: The injected HttpClient's get method is called twice
     """
 
-    class TestHttpClient(HttpClient):
-        counter = 0
-
-        def get(self, url, params=None, **kwargs):
-            self.counter += 1
-            return self.counter
-
     class TestHasher(Hasher):
         counter = 0
 
@@ -141,5 +144,5 @@ def test_ttl_expired():
     caching_client = LruHttpClient(http_client=client, hasher=hasher)
     res1 = caching_client.get("abc")
     res2 = caching_client.get("abc")
-    assert res1 == 1
-    assert res2 == 2
+    assert res1 == 2
+    assert res2 == 3

--- a/test/http/test_lru_http_client.py
+++ b/test/http/test_lru_http_client.py
@@ -34,57 +34,103 @@ def test_invalid_hasher():
         LruHttpClient(hasher=Dummy())
 
 
-def test_get_no_ttl_same_params():
+def test_no_ttl_same_req():
     """
     Given: User hits caching client with same url twice in a row.
-           Normal requests without caching take two seconds each
-    Assert: To get both responses, it takes roughly two seconds
+           Successive (uncached) requests to HttpClient will return
+           different results
+    Assert: Both responses are the same due to caching
     """
 
     class TestHttpClient(HttpClient):
+        count = 1
+
         def get(self, url, params=None, **kwargs):
-            time.sleep(2)
-            return "hello world" if url == "example.com" else "different"
+            self.count += 1
+            return self.count
 
     client = TestHttpClient()
     caching_client = LruHttpClient(http_client=client)
-    t1 = time.time()
     url = "example.com"
     res1 = caching_client.get(url)
     res2 = caching_client.get(url)
-    assert (time.time() - t1) < 2.1
     assert res1 == res2
 
 
-def test_get_no_ttl_diff_params():
+def test_no_ttl_same_req_url_params():
     """
-    Given: User hits caching client with two different urls three
-           times. Normal requests without caching take two seconds
-           each.
-    Assert: The three requests take approximately 4 seconds to run
-            (2 seconds for each unique request), and that the results
-            are matching what is expected
+    Given: User hits caching client with same url and url params dict
+           twice in a row. Successive (uncached) requests to HttpClient
+           will return different results
+    Assert: Both responses are the same due to caching
     """
 
     class TestHttpClient(HttpClient):
+        count = 1
+
         def get(self, url, params=None, **kwargs):
-            time.sleep(2)
-            return "hello world" if url == "different" else "hello"
+            self.count += 1
+            return self.count
+
+    url = "test.com"
+    client = TestHttpClient()
+    caching_client = LruHttpClient(http_client=client)
+    url_params = {"hello": "world"}
+    res1 = caching_client.get(url, params=url_params)
+    res2 = caching_client.get(url, params=url_params)
+    assert res1 == res2
+
+
+def test_get_diff_req():
+    """
+    Given: User hits caching client with two different urls three
+           times. Successive requests to HttpClient injected into
+           LruHttpClient will return different results
+    Assert: Unique requests give different reponsonses and duplicate
+            requests return cached responses
+    """
+
+    class TestHttpClient(HttpClient):
+        count = 1
+
+        def get(self, url, params=None, **kwargs):
+            self.count += 1
+            return self.count
 
     client = TestHttpClient()
     caching_client = LruHttpClient(http_client=client)
-    t2 = time.time()
     res1 = caching_client.get("different")
     res2 = caching_client.get("urls")
     res3 = caching_client.get("different")
-    finished = time.time()
-    assert (finished - t2) > 3.9
-    assert (finished - t2) < 4.1
     assert res1 == res3
     assert res2 != res3
 
 
-def test_get_ttl_expired():
+def test_get_same_url_diff_url_params():
+    """
+    Given: User hits caching client with same URL twice, but
+           different URL params. Successive requests to injected
+           HttpClient will return different results
+    Assert: They are treated as unique requests and get unique
+            responses.
+    """
+
+    class TestHttpClient(HttpClient):
+        count = 1
+
+        def get(self, url, params=None, **kwargs):
+            self.count += 1
+            return self.count
+
+    client = TestHttpClient()
+    caching_client = LruHttpClient(http_client=client)
+    url = "test.come"
+    res1 = caching_client.get(url, params={"a": "b"})
+    res2 = caching_client.get(url, params={"a": "c"})
+    assert res1 != res2
+
+
+def test_ttl_expired():
     """
     Given: User hits caching client with the same url twice.
            The hashing function returns different values for the

--- a/test/http/test_requests_http_client.py
+++ b/test/http/test_requests_http_client.py
@@ -1,0 +1,55 @@
+from lru_cache_http_client.http.requests_http_client import RequestsHttpClient
+
+from collections.abc import Hashable
+import pytest
+
+
+def test_dict_with_unhashable_key():
+    """
+    Given: User passes in url params as dict with value
+           of key that is not hashable
+    Assert: TypeError raised
+    """
+    reqs_client = RequestsHttpClient()
+    url_params = {"1": {"1": "234"}}
+    with pytest.raises(TypeError):
+        reqs_client.make_args_hashable(params=url_params)
+
+
+def test_url_params_list():
+    """
+    Given: User passes in url params as unhashable list
+    Assert: params are returned that are hashable
+    """
+    reqs_client = RequestsHttpClient()
+    url_params = [("a", "b"), ("c", "d")]
+    params, kwargs = reqs_client.make_args_hashable(params=url_params)
+    assert isinstance(params, Hashable)
+
+
+def test_url_params_dict():
+    """
+    Given: User passes in url params as unhashable dict
+    Assert: params are returned that are hashable
+    """
+    reqs_client = RequestsHttpClient()
+    url_params = {"a": "b"}
+    params, kwargs = reqs_client.make_args_hashable(params=url_params)
+    assert isinstance(params, Hashable)
+
+
+def test_hashing_kwargs():
+    """
+    Given: User passes in headers, cookies, proxies that are of type dict
+    Assert: They are returned as being hashable
+    """
+    reqs_client = RequestsHttpClient()
+    url_params = None
+    headers = {"a": "b"}
+    cookies = {"c": "d"}
+    proxies = {"e": 123}
+    params, kwargs = reqs_client.make_args_hashable(
+        params=url_params, cookies=cookies, headers=headers, proxies=proxies
+    )
+    for key, val in kwargs.items():
+        assert isinstance(params, Hashable)


### PR DESCRIPTION
Initially, I forgot that the args passed into the `LruHttpClient.caching_func` needed to be hashable. To handle this, I decided to add a method to the `HttpClient` interface to handle hashing args passed to the `HttpClient.get` method. Then, I added implementation for the `RequestsHttpClient` that hashes the various args passed into `requests.get` that could potentially be unhashable - the url params, headers, cookies, and proxies being the ones I saw in the docs. To my knowledge, the keys and values stored within these dicts/lists are all immutable and hashable, so I created a hashable wrapper around the `dict` class.

This PR also cleans up the tests, and splits the base `HttpClient` into its own file as it's a separate concern from the `RequestsHttpClient`