### PR TITLE
Added IgnoredFieldsHasher

### DIFF
--- a/lru_cache_http_client/hash/ignore_fields_hasher.py
+++ b/lru_cache_http_client/hash/ignore_fields_hasher.py
@@ -1,0 +1,45 @@
+from typing import Union, List
+
+
+class IgnoreFieldsHasher:
+    """
+    Hasher implementation for ignoring arguments
+    """
+
+    ignored_fields: List[Union[int, str]] = []
+
+    def __init__(self, fields: List[Union[int, str]]):
+        self.ignored_fields = fields
+
+    def setup(self, *args, **kwargs):
+        args = list(args)
+        for field in self.ignored_fields:
+            if isinstance(field, int):
+                if field >= len(args):
+                    raise IndexError("Arg at that position does not exist")
+                args[field] = _IgnoredField(args[field])
+            elif isinstance(field, str):
+                kwargs[field] = _IgnoredField(kwargs[field])
+            else:
+                raise IndexError("Invalid ignored field")
+        return tuple(args), kwargs
+
+    def teardown(self, *args, **kwargs):
+        args = list(args)
+        for field in self.ignored_fields:
+            if isinstance(field, int):
+                args[field] = args[field].ignored_val
+            else:
+                kwargs[field] = kwargs[field].ignored_val
+        return tuple(args), kwargs
+
+
+class _IgnoredField:
+
+    ignored_val = None
+
+    def __init__(self, ignored_val):
+        self.ignored_val = ignored_val
+
+    def __hash__(self):
+        return 0

--- a/test/hash/test_ignore_field_hasher.py
+++ b/test/hash/test_ignore_field_hasher.py
@@ -1,0 +1,27 @@
+from lru_cache_http_client.hash.ignore_fields_hasher import IgnoreFieldsHasher
+
+import pytest
+
+
+def test_ignore_field_setup_positional_invalid():
+    ignored_fields = [0, 1]
+    hasher = IgnoreFieldsHasher(ignored_fields)
+    with pytest.raises(IndexError):
+        hasher.setup("a")
+
+
+def test_ignore_field_setup_positional():
+    ignored_fields = [0, 1]
+    hasher = IgnoreFieldsHasher(ignored_fields)
+    args1, _ = hasher.setup("a", "b")
+    args2, _ = hasher.setup("d", "e")
+    assert args1[0].__hash__() == args2[0].__hash__()
+    assert args1[1].__hash__() == args2[1].__hash__()
+
+
+def test_ignore_field_setup_keyword():
+    ignored_fields = ["hello"]
+    hasher = IgnoreFieldsHasher(ignored_fields)
+    _, kwargs1 = hasher.setup(hello="world")
+    _, kwargs2 = hasher.setup(hello="world2")
+    assert kwargs1["hello"].__hash__() == kwargs2["hello"].__hash__()


### PR DESCRIPTION
This PR accomplishes the following:
- adds ability to 'ignore' field when hashing value by returning the same hash for the field